### PR TITLE
Aggressively apply a number of optimization strategies to fix paralla…

### DIFF
--- a/static/css/global.css
+++ b/static/css/global.css
@@ -48,9 +48,8 @@ body {
     position: absolute;
     bottom: 0px;
     left: 0px;
-    width: 100%;
+    min-width: 100%;
     height: 100vh;
-    background-position: bottom;
     /* Reduce repaints */
     will-change: transform;
     transform: translateZ(0);

--- a/static/index.html
+++ b/static/index.html
@@ -10,6 +10,10 @@
 
         <!-- Bootstrap -->
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/css/bootstrap.min.css">
+
+        <!-- jQuery -->
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+        <script src="js/parallax.js"></script>
         
         <!-- Angular -->
         <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.7/angular.min.js"></script>
@@ -34,17 +38,11 @@
             <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
         <![endif]-->
     </head>
-    <body ng-app="meccaApp" ng-controller="mainController">
+    <body ng-app="meccaApp">
 
         <div ng-include="'templates/navbar.html'"></div>
-        <div ng-view></div>
+        <div ng-view ng-controller="mainController"></div>
 
-        <!-- jQuery -->
-        <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
-        <script src="js/parallax.js"></script>
-        <script src="js/jquery.tablesorter.min.js"></script>
-        <script src="js/modelsort.js"></script>
-         
         <!-- Bootstrap -->
         <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.5/js/bootstrap.min.js"></script>
     </body>

--- a/static/js/parallax.js
+++ b/static/js/parallax.js
@@ -1,10 +1,10 @@
 function parallax() {
     var scrolled = $(window).scrollTop();
     $(".parallax-bg").each(function() {
-        $(this).css("transform", "translateY(" + scrolled * $(this).data("speed") + "px)")
+        $(this).css("transform", "translateY(" + scrolled * $(this).data("speed") + "px)");
     });
 }
 
 $(window).bind('scroll', function(e) {
-    parallax();
+    window.requestAnimationFrame(parallax);
 });

--- a/static/templates/artist.html
+++ b/static/templates/artist.html
@@ -1,18 +1,18 @@
 <div id="fixed-width-container" ng-controller="artistController">
     <div class="section-head parallax">
-        <div class="parallax-bg" data-speed="0.2" ng-style="{'background-image':'url(data:image/JPEG;base64,' + artist.banner + ')'}"></div>
-        <div class="parallax-fg">{{ artist.name }}</div>
+        <img class="parallax-bg" data-speed="0.2" src="data:image/JPEG;base64,{{ ::artist.banner }}"/>
+        <div class="parallax-fg">{{ ::artist.name }}</div>
     </div>
     <div class="section">
         
         <!-- Artist Info -->
         <div class="overview">
-            <img ng-src="data:image/JPEG;base64,{{ artist.image }}">
+            <img ng-src="data:image/JPEG;base64,{{ ::artist.image }}">
             <div>
                 <strong class="subsection text-uppercase">Label</strong>
-                <a href="{{ artist.label.url }}">{{ artist.label.name }}</a>
+                <a href="{{ ::artist.label.url }}">{{ ::artist.label.name }}</a>
                 <strong class="subsection text-uppercase">Genre</strong>
-                {{ artist.genre }}
+                {{ ::artist.genre }}
             </div>
         </div>
 
@@ -28,11 +28,11 @@
 
             <!-- Selector content -->
             <div class="padded text-center">
-                <a href="{{ release.url }}" ng-repeat="release in artist.releases">
+                <a href="{{ ::release.url }}" ng-repeat="release in artist.releases">
                     <div class="artist_release">
-                        <img src="data:image/JPEG;base64,{{ release.image }}">
-                        <i>{{ release.name }}</i>
-                        {{ release.year }}
+                        <img src="data:image/JPEG;base64,{{ ::release.image }}">
+                        <i>{{ ::release.name }}</i>
+                        {{ ::release.year }}
                     </div>
                 </a>
             </div>
@@ -40,25 +40,25 @@
     </div>
 
     <div class="section-head parallax">
-        <div class="parallax-bg" data-speed="0.2" ng-style="{'background-image':'url(data:image/JPEG;base64,' + artist.banner + ')'}"></div>
+        <img class="parallax-bg" data-speed="0.2" src="data:image/JPEG;base64,{{ ::artist.banner }}"/>
         <div class="parallax-fg">Upcoming Concerts</div>
     </div>
     <div class="section">
         <div class="panel">
             <div class="event" ng-repeat="event in artist.events">
                 <div class="calendar">
-                    <div>{{ event.date.month }}</div>
-                    {{ event.date.day }}
+                    <div>{{ ::event.date.month }}</div>
+                    {{ ::event.date.day }}
                 </div>
                 <div class="event_info">
-                    <b>{{ event.name }}</b><br>
-                    {{ event.location }}
+                    <b>{{ ::event.name }}</b><br>
+                    {{ ::event.location }}
                 </div>
             </div>
         </div>
     </div>
     <div class="section-head parallax">
-        <div class="parallax-bg" data-speed="0.2" ng-style="{'background-image':'url(data:image/JPEG;base64,' + artist.banner + ')'}"></div>
+        <img class="parallax-bg" data-speed="0.2" src="data:image/JPEG;base64,{{ ::artist.banner }}"/>
         <div class="parallax-fg">Discussion</div>
     </div>
     <div class="section">


### PR DESCRIPTION
…x jank. Fixes #52 

Optimizations include:
1. Use one-time bindings on artist page for all read-only data
2. Use requestAnimationFrame to v-sync parallax updates
3. avoid resizing artist banners when possible (use max-width instead of width)
4. reduce scope of mainController
5. Use img tag instead of inline background-image style
6. reorder js imports to avoid loading jquery twice

Parallax is buttery smooth again even though we're still using base64 images.
The results can now be viewed on downing.club!
